### PR TITLE
Update net_device.h to make mac addresses not const

### DIFF
--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -94,7 +94,7 @@ void tud_network_init_cb(void);
 
 // client must provide this: 48-bit MAC address
 // TODO removed later since it is not part of tinyusb stack
-extern const uint8_t tud_network_mac_address[6];
+extern uint8_t tud_network_mac_address[6];
 
 //------------- NCM -------------//
 


### PR DESCRIPTION
Per #718, MAC addresses are intended to be device unique, and thus should NOT be defined as consts.

I'm not sure what the longer term fix in the TODO should be, but this is a simple fix.